### PR TITLE
ci: apk_release.yml 추출 경로 수정(#11)

### DIFF
--- a/.github/workflows/apk_release.yml
+++ b/.github/workflows/apk_release.yml
@@ -1,10 +1,8 @@
 name: Android APK Release
 
 on:
-  push:
-    branches: [ "main", "develop"]
   pull_request:
-    branches: [ "develop" ]
+    branches: [ "main" ]
 
 jobs:
   apk:
@@ -23,7 +21,7 @@ jobs:
       - name: Build debug APK
         run: bash ./gradlew assembleDebug --stacktrace
 
-      - name: Upload APK
+      - name: Upload Debug APK
         uses: actions/upload-artifact@v3
         with:
           name: app

--- a/.github/workflows/apk_release.yml
+++ b/.github/workflows/apk_release.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app
-          path: data/debug
+          path: presentation/build/outputs/apk/debug/presentation-release-unsigned.apk

--- a/.github/workflows/apk_release.yml
+++ b/.github/workflows/apk_release.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app
-          path: presentation/build/outputs/apk/debug/presentation-release-unsigned.apk
+          path: presentation/build/outputs/apk/debug


### PR DESCRIPTION
# ✒️ 관련 이슈번호
- Closes #11 

# 🔑 Key Changes
- apk_release.yml의 path 수정 ( app 모듈 대신 presentation으로 구성되어 있으므로, app -> presentation으로 바꿔 줌)
- intellji 터미널에서 ./gradlew assembleDebug를 했을 때, apk가 생기는 경로를 작성해주어야 함 ( intellij-> build에서 뽑는 경로와는 다름)
# 📢 To Reviewers